### PR TITLE
Update dependencies with python 3.12 to sync with NiChart Workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It is available both as an installable package, as well as a [docker container](
 1. Create a new conda env
 
     ```bash
-    conda create --name NCP python=3.8
+    conda create --name NCP python=3.12
     conda activate NCP
     ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Babel==2.15.0
 beautifulsoup4==4.12.3
 Brotli==1.1.0
 CacheControl==0.14.0
-certifi==2024.7.4 
+certifi==2024.7.4
 cfgv==3.4.0
 charset-normalizer==3.3.2
 colorlog==6.8.2
@@ -24,7 +24,7 @@ fonttools==4.53.1
 fsspec==2024.6.1
 html5lib==1.1
 identify==2.6.0
-idna==3.7 
+idna==3.7
 imagesize==1.4.1
 importlib_metadata==8.0.0
 importlib_resources==6.4.0
@@ -49,7 +49,7 @@ numpy==2.0.0
 oauthlib==3.2.2
 optuna==3.6.1
 packaging==24.1
-pandas==2.0.3
+pandas==2.2.0
 pillow==10.4.0
 platformdirs==4.2.2
 pooch==1.8.2
@@ -90,7 +90,7 @@ tabulate==0.9.0
 threadpoolctl==3.5.0
 tomli==2.0.1
 tomlkit==0.13.0
-torch==2.2.1
+torch==2.3.1
 torchvision==0.17.1
 tqdm==4.66.4
 typing_extensions==4.12.2
@@ -99,3 +99,4 @@ urllib3==2.2.2
 virtualenv==20.26.3
 webencodings==0.5.1
 zipp==3.19.2
+

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ setup(
     license="MIT",
     url="https://github.com/CBICA/NiChart_DLMUSE",
     install_requires=[
-        'torch<2.1; platform_system=="Darwin"',  # macOS
-        'torch<2.1; platform_system!="Darwin"',  # Linux and Windows
+        'torch==2.3.1; platform_system=="Darwin"',  # macOS
+        'torch==2.3.1; platform_system!="Darwin"',  # Linux and Windows
         "nnunet==1.7.1",
         "tqdm",
         "dicom2nifti",
@@ -42,7 +42,7 @@ setup(
         "nibabel==3.2.1",
         "resource==0.2.1",
         "networkx>=2.5.1",
-        "pandas==1.2.5",
+        "pandas==2.2.0",
         "pathlib",
     ],
     entry_points={"console_scripts": ["NiChart_DLMUSE = NiChart_DLMUSE.__main__:main"]},
@@ -55,3 +55,4 @@ setup(
     packages=setuptools.find_packages(),
     include_package_data=True,
 )
+


### PR DESCRIPTION
Now torch, pandas and numpy will be updated with the new package of >=2.0.0. Conda env will run with python 3.12 as python 3.8 support is slowly going away