### PR TITLE
Correct dependencies for sphinx workflow

### DIFF
--- a/.github/workflows/sphinx-docs.yml
+++ b/.github/workflows/sphinx-docs.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.12.4"
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ threadpoolctl==3.5.0
 tomli==2.0.1
 tomlkit==0.13.0
 torch==2.3.1
-torchvision==0.17.1
+torchvision==0.19.0
 tqdm==4.66.4
 typing_extensions==4.12.2
 tzdata==2024.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ threadpoolctl==3.5.0
 tomli==2.0.1
 tomlkit==0.13.0
 torch==2.3.1
-torchvision==0.19.0
+torchvision==0.18.1
 tqdm==4.66.4
 typing_extensions==4.12.2
 tzdata==2024.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ joblib==1.4.2
 kiwisolver==1.4.5
 Mako==1.3.5
 MarkupSafe==2.1.5
-matplotlib==3.9.1
+matplotlib==3.9.2
 mccabe==0.7.0
 more-itertools==10.3.0
 mpmath==1.3.0
@@ -49,7 +49,7 @@ numpy==2.0.0
 oauthlib==3.2.2
 optuna==3.6.1
 packaging==24.1
-pandas==2.2.0
+pandas==2.2.2
 pillow==10.4.0
 platformdirs==4.2.2
 pooch==1.8.2
@@ -99,4 +99,3 @@ urllib3==2.2.2
 virtualenv==20.26.3
 webencodings==0.5.1
 zipp==3.19.2
-

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "tifffile",
         "setuptools",
         "nipype",
-        "matplotlib>=3.3.3",
+        "matplotlib==3.9.2",
         "dill>=0.3.4",
         "h5py",
         "hyperopt==0.2.5",
@@ -42,7 +42,7 @@ setup(
         "nibabel==3.2.1",
         "resource==0.2.1",
         "networkx>=2.5.1",
-        "pandas==2.2.0",
+        "pandas==2.2.2",
         "pathlib",
     ],
     entry_points={"console_scripts": ["NiChart_DLMUSE = NiChart_DLMUSE.__main__:main"]},
@@ -55,4 +55,3 @@ setup(
     packages=setuptools.find_packages(),
     include_package_data=True,
 )
-


### PR DESCRIPTION
### Dependencies update
We will work with torch 2.3.1, so i updated it with the correct torchvision and matplotlib version. Now the sphinx-doc is building correctly. I checked it locally and thought it will be fine but it wasn't, now it works.