### PR TITLE
Make sure that subfolders array is correct

### DIFF
--- a/NiChart_DLMUSE/utils.py
+++ b/NiChart_DLMUSE/utils.py
@@ -176,6 +176,9 @@ def split_data(in_dir: str, N: int) -> list:
             os.system(f"cp {file} {in_dir}/split_{current_folder}")
             current_file += 1
 
+    if current_file > 0:
+        subfolders.append(f"{in_dir}/split_{current_folder}")
+
     return subfolders
 
 


### PR DESCRIPTION
### Parallelization issue

The subfolders array was empty if we only had one file because it never excedeed the maximum files on subfolders, so it was never added in the array. Now this is fixed.
Please @AlexanderGetka-cbica check it yourself as well, i tested it and it worked fine.