### PR TITLE
BIDS I/O(Without json files) and codecov test cases for NiChart_DLMUSE

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -11,12 +11,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Set-up miniconda for macos and ubuntu
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: 3.12
+          python-version: 3.13
           miniconda-version: "latest"
       - name: Create conda env
         run: conda create -n NCP python=3.12

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -1,4 +1,4 @@
-name: NiChart_DLMUSE building test for macos
+name: MacOS Build
 
 # workflow dispatch has been added for testing purposes
 on: [push, pull_request, workflow_dispatch]

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -11,12 +11,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.12"
       - name: Set-up miniconda for macos and ubuntu
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: 3.13
+          python-version: 3.12
           miniconda-version: "latest"
       - name: Create conda env
         run: conda create -n NCP python=3.12

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -24,6 +24,7 @@ jobs:
         run: conda run -n NCP conda install pip
       - name: Build NiChart_DLMUSE from source
         run: |
+          python -m pip cache purge
           pip install setuptools twine wheel
           pip install -r requirements.txt
           python3 -m pip install -e .

--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -20,4 +20,9 @@ jobs:
           python -m pip install .
       - name: Run unit tests
         run: |
-          cd tests/ && pytest --cov=../
+          cd tests/ && pytest --cov=../ --cov-report=xml
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: CBICA/NiChart_DLMUSE

--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -1,0 +1,23 @@
+name: macos build
+
+# workflow dispatch has been added for testing purposes
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ["macos-13"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install spare scores
+        run: |
+          python -m pip cache purge
+          pip install -r requirements.txt
+          pip install setuptools twine wheel
+          python -m pip install .
+      - name: Run unit tests
+        run: |
+          cd tests/ && pytest --cov=../

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -11,12 +11,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Set-up miniconda for macos and ubuntu
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: 3.12
+          python-version: 3.13
           miniconda-version: "latest"
       - name: Create conda env
         run: conda create -n NCP python=3.12

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -11,12 +11,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.12"
       - name: Set-up miniconda for macos and ubuntu
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: 3.13
+          python-version: 3.12
           miniconda-version: "latest"
       - name: Create conda env
         run: conda create -n NCP python=3.12

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -24,6 +24,7 @@ jobs:
         run: conda run -n NCP conda install pip
       - name: Build NiChart_DLMUSE from source
         run: |
+          python -m pip cache purge
           pip install setuptools twine wheel
           pip install -r requirements.txt
           python3 -m pip install -e .

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -1,4 +1,4 @@
-name: NiChart_DLMUSE building test for ubuntu
+name: Ubuntu Build
 
 # workflow dispatch has been added for testing purposes
 on: [push, pull_request, workflow_dispatch]

--- a/.github/workflows/ubuntu_tests.yml
+++ b/.github/workflows/ubuntu_tests.yml
@@ -1,0 +1,23 @@
+name: ubuntu tests
+
+# workflow dispatch has been added for testing purposes
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ["ubuntu-latest"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install spare scores
+        run: |
+          python -m pip cache purge
+          pip install -r requirements.txt
+          pip install setuptools twine wheel
+          python -m pip install .
+      - name: Run unit tests
+        run: |
+          cd tests && pytest --cov=../

--- a/.github/workflows/ubuntu_tests.yml
+++ b/.github/workflows/ubuntu_tests.yml
@@ -20,4 +20,4 @@ jobs:
           python -m pip install .
       - name: Run unit tests
         run: |
-          cd tests && pytest --cov=../
+          cd tests && pytest

--- a/NiChart_DLMUSE/__main__.py
+++ b/NiChart_DLMUSE/__main__.py
@@ -179,6 +179,7 @@ def main() -> None:
         for t in threads:
             t.join()
 
+        # TODO | FIX: Transform normal output data to BIDS output
         merge_output_data(out_dir)
         merge_bids_output_data(out_dir)
         remove_subfolders("raw_temp_T1")

--- a/NiChart_DLMUSE/__main__.py
+++ b/NiChart_DLMUSE/__main__.py
@@ -10,7 +10,7 @@ import os
 import threading
 
 from .dlmuse_pipeline import run_pipeline
-from .utils import merge_output_data, remove_subfolders, split_data, collect_T1
+from .utils import merge_bids_output_data, merge_output_data, remove_subfolders, split_data, collect_T1
 
 # VERSION = pkg_resources.require("NiChart_DLMUSE")[0].version
 VERSION = "1.0.5"
@@ -141,7 +141,10 @@ def main() -> None:
     print(args)
     print()
 
-    if len(os.listdir(out_dir)) != 0:
+    if not os.path.isdir(out_dir):
+        print(f"Can't find {out_dir}, creating it...")
+        os.system(f"mkdir {out_dir}")
+    elif len(os.listdir(out_dir)) != 0:
         print(f"Emptying output folder: {out_dir}...")
         os.system(f"rm -r {out_dir}/*")
 
@@ -152,7 +155,7 @@ def main() -> None:
 
     # Run pipeline
     if args.bids == True:
-        collect_T1(in_dir)
+        collect_T1(in_dir, out_dir)
 
         no_threads = int(args.cores)
         subfolders = split_data("raw_temp_T1", no_threads)
@@ -177,9 +180,9 @@ def main() -> None:
             t.join()
 
         merge_output_data(out_dir)
+        merge_bids_output_data(out_dir)
         remove_subfolders("raw_temp_T1")
         remove_subfolders(out_dir)
-
 
     else:
         no_threads = int(args.cores)

--- a/NiChart_DLMUSE/__main__.py
+++ b/NiChart_DLMUSE/__main__.py
@@ -184,7 +184,7 @@ def main() -> None:
         # TODO | FIX: Transform normal output data to BIDS output
 
         merge_bids_output_data(working_dir)
-        remove_subfolders("../raw_temp_T1")
+        remove_subfolders("raw_temp_T1")
         remove_subfolders(out_dir)
 
     else:

--- a/NiChart_DLMUSE/__main__.py
+++ b/NiChart_DLMUSE/__main__.py
@@ -181,8 +181,6 @@ def main() -> None:
         for t in threads:
             t.join()
 
-        # TODO | FIX: Transform normal output data to BIDS output
-
         merge_bids_output_data(working_dir)
         remove_subfolders("raw_temp_T1")
         remove_subfolders(out_dir)

--- a/NiChart_DLMUSE/__main__.py
+++ b/NiChart_DLMUSE/__main__.py
@@ -153,6 +153,7 @@ def main() -> None:
         os.system("DLICV -i ./dummy -o ./dummy --clear_cache")
         os.system("DLMUSE -i ./dummy -o ./dummy --clear_cache")
 
+    working_dir = os.path.join(os.path.abspath(out_dir))
 
     # Run pipeline
     if args.bids == True:
@@ -182,8 +183,7 @@ def main() -> None:
 
         # TODO | FIX: Transform normal output data to BIDS output
 
-        merge_output_data(out_dir)
-        merge_bids_output_data(out_dir)
+        merge_bids_output_data(working_dir)
         remove_subfolders("../raw_temp_T1")
         remove_subfolders(out_dir)
 

--- a/NiChart_DLMUSE/__main__.py
+++ b/NiChart_DLMUSE/__main__.py
@@ -13,7 +13,7 @@ from .dlmuse_pipeline import run_pipeline
 from .utils import merge_bids_output_data, merge_output_data, remove_subfolders, split_data, collect_T1
 
 # VERSION = pkg_resources.require("NiChart_DLMUSE")[0].version
-VERSION = "1.0.5"
+VERSION = "1.0.7"
 
 
 def main() -> None:
@@ -144,6 +144,7 @@ def main() -> None:
     if not os.path.isdir(out_dir):
         print(f"Can't find {out_dir}, creating it...")
         os.system(f"mkdir {out_dir}")
+
     elif len(os.listdir(out_dir)) != 0:
         print(f"Emptying output folder: {out_dir}...")
         os.system(f"rm -r {out_dir}/*")
@@ -180,9 +181,10 @@ def main() -> None:
             t.join()
 
         # TODO | FIX: Transform normal output data to BIDS output
+
         merge_output_data(out_dir)
         merge_bids_output_data(out_dir)
-        remove_subfolders("raw_temp_T1")
+        remove_subfolders("../raw_temp_T1")
         remove_subfolders(out_dir)
 
     else:

--- a/NiChart_DLMUSE/__main__.py
+++ b/NiChart_DLMUSE/__main__.py
@@ -10,7 +10,13 @@ import os
 import threading
 
 from .dlmuse_pipeline import run_pipeline
-from .utils import merge_bids_output_data, merge_output_data, remove_subfolders, split_data, collect_T1
+from .utils import (
+    collect_T1,
+    merge_bids_output_data,
+    merge_output_data,
+    remove_subfolders,
+    split_data,
+)
 
 # VERSION = pkg_resources.require("NiChart_DLMUSE")[0].version
 VERSION = "1.0.7"
@@ -89,7 +95,7 @@ def main() -> None:
         type=bool,
         help="Specify if the provided dataset is BIDS type",
         default=False,
-        required=False
+        required=False,
     )
 
     # VERSION argument
@@ -156,7 +162,7 @@ def main() -> None:
     working_dir = os.path.join(os.path.abspath(out_dir))
 
     # Run pipeline
-    if args.bids == True:
+    if args.bids is True:
         collect_T1(in_dir, out_dir)
 
         no_threads = int(args.cores)

--- a/NiChart_DLMUSE/utils.py
+++ b/NiChart_DLMUSE/utils.py
@@ -211,7 +211,7 @@ def merge_bids_output_data(out_data: str) -> None:
         if get_bids_prefix(split, True) == "split":
             s5_relabeled_dir = os.path.join(out_data, split, "temp_working_dir", "s5_relabeled")
             for img in os.listdir(s5_relabeled_dir):
-                os.system(f"mv {s5_relabeled_dir}/{img} {out_data}/{get_bids_prefix(img)}/anat/")
+                os.system(f"mv {s5_relabeled_dir}/{img} {out_data}/{get_bids_prefix(img, True)}/anat/")
 
 def split_data(in_dir: str, N: int) -> list:
     """

--- a/NiChart_DLMUSE/utils.py
+++ b/NiChart_DLMUSE/utils.py
@@ -249,9 +249,16 @@ def split_data(in_dir: str, N: int) -> list:
             os.system(f"cp {file} {in_dir}/split_{current_folder}")
             current_file += 1
 
-    if current_file < no_files_in_folders:
+    if current_file <= no_files_in_folders:
         # Don't forget the last split if it has less files than the maximum files in a subfolder
         subfolders.append(f"{in_dir}/split_{current_folder}")
+
+    for subfldr in os.listdir(in_dir):
+        joined_folder = os.path.join(in_dir, subfldr)
+        if os.path.isdir(joined_folder):
+            if len(os.listdir(joined_folder)) == 0:
+                os.system(f"rm -r {joined_folder}")
+                subfolders.remove(f"{joined_folder}")
 
     return subfolders
 

--- a/NiChart_DLMUSE/utils.py
+++ b/NiChart_DLMUSE/utils.py
@@ -178,11 +178,11 @@ def collect_T1(in_dir: str, out_dir: str) -> None:
     This function collects all the raw T1 images from the passed BIDS input dir and
     it creates a temporary folder that will act as a generic dataset with only T1 images
     """
-    if os.path.isdir("../raw_temp_T1") and len(os.listdir("../raw_temp_T1")):
-        os.system("rm -r ../raw_temp_T1/*")
-    elif not os.path.isdir("../raw_temp_T1"):
+    if os.path.isdir("raw_temp_T1") and len(os.listdir("raw_temp_T1")):
+        os.system("rm -r raw_temp_T1/*")
+    elif not os.path.isdir("raw_temp_T1"):
         # create the raw_temp_T1 folder that will host all the T1 images
-        os.system("mkdir ../raw_temp_T1")
+        os.system("mkdir raw_temp_T1")
 
     os.system(f"cp -r {in_dir}/* {out_dir}/")
 

--- a/NiChart_DLMUSE/utils.py
+++ b/NiChart_DLMUSE/utils.py
@@ -146,6 +146,8 @@ def get_bids_prefix(filename: str, folder: bool = False) -> str:
     while char != checker:
         prefix += char
         idx += 1
+        if idx >= len(filename):
+            break
         char = filename[idx]
 
     return prefix
@@ -208,7 +210,7 @@ def merge_bids_output_data(out_data: str) -> None:
     for split in os.listdir(out_data):
         if get_bids_prefix(split, True) == "split":
             s5_relabeled_dir = os.path.join(out_data, split, "temp_working_dir", "s5_relabeled")
-            for img in s5_relabeled_dir:
+            for img in os.listdir(s5_relabeled_dir):
                 os.system(f"mv {s5_relabeled_dir}/{img} {out_data}/{get_bids_prefix(img)}/anat/")
 
 def split_data(in_dir: str, N: int) -> list:

--- a/NiChart_DLMUSE/utils.py
+++ b/NiChart_DLMUSE/utils.py
@@ -147,6 +147,44 @@ def dir_size(in_dir: str) -> int:
 
     return size
 
+def dir_foldercount(in_dir: str) -> int:
+    """
+    Returns the number of subfolders that the input directory has
+    """
+
+    size = 0
+    for path in os.listdir(in_dir):
+        if os.path.isdir(os.path.join(in_dir, path)):
+            size += 1
+
+    return size
+
+
+def collect_T1(in_dir: str) -> None:
+    """
+    This function collects all the raw T1 images from the passed BIDS input dir and
+    it creates a temporary folder that will act as a generic dataset with only T1 images
+    """
+    if os.path.isdir("raw_temp_T1"):
+        os.system("rm -r raw_temp_T1/*")
+    else:
+        # create the raw_temp_T1 folder that will host all the T1 images
+        os.system("mkdir raw_temp_T1")
+
+    total_subs = dir_foldercount(in_dir)
+    accepted_subfolders = []
+    for i in range(1, total_subs):
+        if i < 10:
+            accepted_subfolders.append(f"sub-0{i}")
+        else:
+            accepted_subfolders.append(f"sub-{i}")
+
+    for root, subs, files in os.walk(in_dir):
+        for sub in subs:
+            if(sub in accepted_subfolders):
+                os.system(f"cp {os.path.join(in_dir, sub)}/anat/* raw_temp_T1")
+
+
 
 def split_data(in_dir: str, N: int) -> list:
     """
@@ -175,6 +213,10 @@ def split_data(in_dir: str, N: int) -> list:
         if os.path.isfile(file):
             os.system(f"cp {file} {in_dir}/split_{current_folder}")
             current_file += 1
+
+    if current_file < no_files_in_folders:
+        # Don't forget the last split if it has less files than the maximum files in a subfolder
+        subfolders.append(f"{in_dir}/split_{current_folder}")
 
     return subfolders
 

--- a/NiChart_DLMUSE/utils.py
+++ b/NiChart_DLMUSE/utils.py
@@ -135,14 +135,15 @@ def make_img_list(in_data: str) -> pd.DataFrame:
     # Return out dataframe
     return df_out
 
-def get_bids_prefix(filename: str) -> str:
+def get_bids_prefix(filename: str, folder: bool = False) -> str:
     """
     Returns the prefix of a bids file
     """
+    checker = '-' if folder is False else '_'
     prefix = ""
     idx = 0
     char = filename[idx]
-    while char != '_':
+    while char != checker:
         prefix += char
         idx += 1
         char = filename[idx]
@@ -205,7 +206,7 @@ def merge_bids_output_data(out_data: str) -> None:
     Move all the images on the s5_relabeled subfolder to the subfolder of their prefix
     """
     for split in os.listdir(out_data):
-        if get_bids_prefix(split) == "split_":
+        if get_bids_prefix(split, True) == "split":
             s5_relabeled_dir = os.path.join(out_data, split, "temp_working_dir", "s5_relabeled")
             for img in s5_relabeled_dir:
                 os.system(f"mv {s5_relabeled_dir}/{img} {out_data}/{get_bids_prefix(img)}/anat/")

--- a/NiChart_DLMUSE/utils.py
+++ b/NiChart_DLMUSE/utils.py
@@ -178,38 +178,36 @@ def collect_T1(in_dir: str, out_dir: str) -> None:
     This function collects all the raw T1 images from the passed BIDS input dir and
     it creates a temporary folder that will act as a generic dataset with only T1 images
     """
-    if os.path.isdir("raw_temp_T1"):
-        os.system("rm -r raw_temp_T1/*")
-    else:
+    if os.path.isdir("../raw_temp_T1") and len(os.listdir("../raw_temp_T1")):
+        os.system("rm -r ../raw_temp_T1/*")
+    elif not os.path.isdir("../raw_temp_T1"):
         # create the raw_temp_T1 folder that will host all the T1 images
-        os.system("mkdir raw_temp_T1")
+        os.system("mkdir ../raw_temp_T1")
 
     os.system(f"cp -r {in_dir}/* {out_dir}/")
 
     total_subs = dir_foldercount(in_dir)
     accepted_subfolders = []
-    for i in range(1, total_subs):
-        if i < 10:
-            accepted_subfolders.append(f"sub-0{i}")
+    for i in range(total_subs):
+        if i < 9:
+            accepted_subfolders.append(f"sub-0{i + 1}")
         else:
-            accepted_subfolders.append(f"sub-{i}")
+            accepted_subfolders.append(f"sub-{i + 1}")
 
     for root, subs, files in os.walk(in_dir):
         for sub in subs:
             if(sub in accepted_subfolders):
-                os.system(f"cp {os.path.join(in_dir, sub)}/anat/* raw_temp_T1")
+                os.system(f"cp {os.path.join(in_dir, sub)}/anat/* raw_temp_T1/")
 
 
 def merge_bids_output_data(out_data: str) -> None:
     """
     Move all the images on the s5_relabeled subfolder to the subfolder of their prefix
     """
-    dlmuse_images = []
     relabeled_dir = os.path.join(out_data, "s5_relabeled")
     for img in os.listdir(relabeled_dir):
         img_prefix = get_bids_prefix(img)
         os.system(f"mv {relabeled_dir}/{img} {img_prefix}/anat/")
-
 
 def split_data(in_dir: str, N: int) -> list:
     """

--- a/NiChart_DLMUSE/utils.py
+++ b/NiChart_DLMUSE/utils.py
@@ -204,10 +204,11 @@ def merge_bids_output_data(out_data: str) -> None:
     """
     Move all the images on the s5_relabeled subfolder to the subfolder of their prefix
     """
-    relabeled_dir = os.path.join(out_data, "s5_relabeled")
-    for img in os.listdir(relabeled_dir):
-        img_prefix = get_bids_prefix(img)
-        os.system(f"mv {relabeled_dir}/{img} {img_prefix}/anat/")
+    for split in os.listdir(out_data):
+        if get_bids_prefix(split) == "split_":
+            s5_relabeled_dir = os.path.join(out_data, split, "temp_working_dir", "s5_relabeled")
+            for img in s5_relabeled_dir:
+                os.system(f"mv {s5_relabeled_dir}/{img} {out_data}/{get_bids_prefix(img)}/anat/")
 
 def split_data(in_dir: str, N: int) -> list:
     """

--- a/NiChart_DLMUSE/utils.py
+++ b/NiChart_DLMUSE/utils.py
@@ -135,6 +135,19 @@ def make_img_list(in_data: str) -> pd.DataFrame:
     # Return out dataframe
     return df_out
 
+def get_bids_prefix(filename: str) -> str:
+    """
+    Returns the prefix of a bids file
+    """
+    prefix = ""
+    idx = 0
+    char = filename[idx]
+    while char != '_':
+        prefix += char
+        idx += 1
+        char = filename[idx]
+
+    return prefix
 
 def dir_size(in_dir: str) -> int:
     """
@@ -160,7 +173,7 @@ def dir_foldercount(in_dir: str) -> int:
     return size
 
 
-def collect_T1(in_dir: str) -> None:
+def collect_T1(in_dir: str, out_dir: str) -> None:
     """
     This function collects all the raw T1 images from the passed BIDS input dir and
     it creates a temporary folder that will act as a generic dataset with only T1 images
@@ -170,6 +183,8 @@ def collect_T1(in_dir: str) -> None:
     else:
         # create the raw_temp_T1 folder that will host all the T1 images
         os.system("mkdir raw_temp_T1")
+
+    os.system(f"cp -r {in_dir}/* {out_dir}/")
 
     total_subs = dir_foldercount(in_dir)
     accepted_subfolders = []
@@ -183,6 +198,17 @@ def collect_T1(in_dir: str) -> None:
         for sub in subs:
             if(sub in accepted_subfolders):
                 os.system(f"cp {os.path.join(in_dir, sub)}/anat/* raw_temp_T1")
+
+
+def merge_bids_output_data(out_data: str) -> None:
+    """
+    Move all the images on the s5_relabeled subfolder to the subfolder of their prefix
+    """
+    dlmuse_images = []
+
+    for img in os.listdir(os.path.join(out_data, "s5_relabeled")):
+        img_prefix = get_bids_prefix(img)
+        os.system(f"mv {os.path.join(out_data, "s5_relabeled")}/{img} {img_prefix}/anat/")
 
 
 
@@ -231,37 +257,36 @@ def remove_subfolders(in_dir: str) -> None:
 def merge_output_data(in_dir: str) -> None:
     """
     Takes all the results from the temp_working_fir and moves them into
-    the results/ subfolder in the output folder
+    the output folder
     """
 
-    os.system(f"mkdir {in_dir}/results")
-    os.system(f"mkdir {in_dir}/results/s1_reorient_lps")
-    os.system(f"mkdir {in_dir}/results/s2_dlicv")
-    os.system(f"mkdir {in_dir}/results/s3_masked")
-    os.system(f"mkdir {in_dir}/results/s4_dlmuse")
-    os.system(f"mkdir {in_dir}/results/s5_relabeled")
-    os.system(f"mkdir {in_dir}/results/s6_combined")
+    os.system(f"mkdir {in_dir}/s1_reorient_lps")
+    os.system(f"mkdir {in_dir}/s2_dlicv")
+    os.system(f"mkdir {in_dir}/s3_masked")
+    os.system(f"mkdir {in_dir}/s4_dlmuse")
+    os.system(f"mkdir {in_dir}/s5_relabeled")
+    os.system(f"mkdir {in_dir}/s6_combined")
 
     for dir in os.listdir(in_dir):
         if dir == "results":
             continue
 
         os.system(
-            f"mv {in_dir}/{dir}/temp_working_dir/s1_reorient_lps/* {in_dir}/results/s1_reorient_lps/"
+            f"mv {in_dir}/{dir}/temp_working_dir/s1_reorient_lps/* {in_dir}/s1_reorient_lps/"
         )
         os.system(
-            f"mv {in_dir}/{dir}/temp_working_dir/s2_dlicv/* {in_dir}/results/s2_dlicv/"
+            f"mv {in_dir}/{dir}/temp_working_dir/s2_dlicv/* {in_dir}/s2_dlicv/"
         )
         os.system(
-            f"mv {in_dir}/{dir}/temp_working_dir/s3_masked/* {in_dir}/results/s3_masked/"
+            f"mv {in_dir}/{dir}/temp_working_dir/s3_masked/* {in_dir}/s3_masked/"
         )
         os.system(
-            f"mv {in_dir}/{dir}/temp_working_dir/s4_dlmuse/* {in_dir}/results/s4_dlmuse/"
+            f"mv {in_dir}/{dir}/temp_working_dir/s4_dlmuse/* {in_dir}/s4_dlmuse/"
         )
         os.system(
-            f"mv {in_dir}/{dir}/temp_working_dir/s5_relabeled/* {in_dir}/results/s5_relabeled/"
+            f"mv {in_dir}/{dir}/temp_working_dir/s5_relabeled/* {in_dir}/s5_relabeled/"
         )
         os.system(
-            f"mv {in_dir}/{dir}/temp_working_dir/s6_combined/* {in_dir}/results/s6_combined/"
+            f"mv {in_dir}/{dir}/temp_working_dir/s6_combined/* {in_dir}/s6_combined/"
         )
-        os.system(f"mv {in_dir}/{dir}/*.nii.gz {in_dir}/results/")
+        os.system(f"mv {in_dir}/{dir}/*.nii.gz {in_dir}/")

--- a/NiChart_DLMUSE/utils.py
+++ b/NiChart_DLMUSE/utils.py
@@ -77,6 +77,12 @@ def remove_common_suffix(list_files: list) -> list:
 def make_img_list(in_data: str) -> pd.DataFrame:
     """
     Make a list of images
+
+    :param in_data: the input directory
+    :type in_data: str
+
+    :return: a dataframe with the information about the passed data
+    :rtype: pd.DataFrame
     """
 
     # Read list of input images
@@ -139,6 +145,14 @@ def make_img_list(in_data: str) -> pd.DataFrame:
 def get_bids_prefix(filename: str, folder: bool = False) -> str:
     """
     Returns the prefix of a bids file
+    :param filename: The passed file
+    :type filename: str
+
+    :param folder: True if the passed filename is a folder or False if it's not
+    :type folder: bool
+
+    :return: The prefix of the bids i/o
+    :rtype: str
     """
     checker = "-" if folder is False else "_"
     prefix = ""
@@ -157,6 +171,12 @@ def get_bids_prefix(filename: str, folder: bool = False) -> str:
 def dir_size(in_dir: str) -> int:
     """
     Returns the number of images the user passed
+
+    :param in_dir: the input directory
+    :type in_dir: str
+
+    :return: The size of the passsed directory
+    :rtype: int
     """
     size = 0
     for path in os.listdir(in_dir):
@@ -169,6 +189,12 @@ def dir_size(in_dir: str) -> int:
 def dir_foldercount(in_dir: str) -> int:
     """
     Returns the number of subfolders that the input directory has
+
+    :param in_dir: the input directory
+    :type in_dir: str
+
+    :return: the number of folders in the input directory
+    :rtype: int
     """
 
     size = 0
@@ -183,6 +209,14 @@ def collect_T1(in_dir: str, out_dir: str) -> None:
     """
     This function collects all the raw T1 images from the passed BIDS input dir and
     it creates a temporary folder that will act as a generic dataset with only T1 images
+
+    :param in_dir: the input directory
+    :type in_dir: str
+
+    :param out_dir: the output directory
+    :type out_dir: str
+
+    :rtype: None
     """
     if os.path.isdir("raw_temp_T1") and len(os.listdir("raw_temp_T1")):
         os.system("rm -r raw_temp_T1/*")
@@ -209,6 +243,11 @@ def collect_T1(in_dir: str, out_dir: str) -> None:
 def merge_bids_output_data(out_data: str) -> None:
     """
     Move all the images on the s5_relabeled subfolder to the subfolder of their prefix
+
+    :param out_data: the output_directory
+    :type out_data: str
+
+    :rtype: None
     """
     for split in os.listdir(out_data):
         if get_bids_prefix(split, True) == "split":
@@ -225,6 +264,15 @@ def split_data(in_dir: str, N: int) -> list:
     """
     Splits the input data directory into subfolders of size.
     N should be > 0 and the number of files in each subfolder should be > 0 as well.
+
+    :param in_dir: the input directory
+    :type in_dir: str
+
+    :param N: the number of generated split folders
+    :type N: int
+
+    :return: a list of the subfolders name
+    :rtype: list
     """
     assert N > 0
     data_size = dir_size(in_dir)
@@ -266,6 +314,11 @@ def split_data(in_dir: str, N: int) -> list:
 def remove_subfolders(in_dir: str) -> None:
     """
     Removes all the split_* subolders from the input folder
+
+    :param in_dir: the input directory
+    :type in_dir: str
+
+    :rtype: None
     """
     os.system(f"rm -r {in_dir}/split_*")
 
@@ -274,6 +327,11 @@ def merge_output_data(in_dir: str) -> None:
     """
     Takes all the results from the temp_working_fir and moves them into
     the output folder
+
+    :param in_dir: the input directory
+    :type in_dir: str
+
+    :rtype: None
     """
 
     os.system(f"mkdir {in_dir}/s1_reorient_lps")

--- a/NiChart_DLMUSE/utils.py
+++ b/NiChart_DLMUSE/utils.py
@@ -2,7 +2,7 @@ import glob
 import logging
 import os
 import re
-from typing import Any
+from typing import Any, Optional
 
 import numpy as np
 import pandas as pd
@@ -14,8 +14,8 @@ logging.basicConfig(filename="pipeline.log", encoding="utf-8", level=logging.DEB
 
 
 def get_basename(
-    in_file: Any, suffix_to_remove: Any, ext_to_remove: Any = LIST_IMG_EXT
-) -> Any:
+    in_file: str, suffix_to_remove: str, ext_to_remove: list = LIST_IMG_EXT
+) -> str:
     """
     Get file basename
     - Extracts the base name from the input file
@@ -34,7 +34,7 @@ def get_basename(
     """
     # Get file basename
     out_str = os.path.basename(in_file)
-
+    num_repl: Optional[int] = None
     # Remove suffix and extension
     for tmp_ext in ext_to_remove:
         out_str, num_repl = re.subn(suffix_to_remove + tmp_ext + "$", "", out_str)

--- a/NiChart_DLMUSE/utils.py
+++ b/NiChart_DLMUSE/utils.py
@@ -2,7 +2,7 @@ import glob
 import logging
 import os
 import re
-from typing import Any, Optional
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -135,11 +135,12 @@ def make_img_list(in_data: str) -> pd.DataFrame:
     # Return out dataframe
     return df_out
 
+
 def get_bids_prefix(filename: str, folder: bool = False) -> str:
     """
     Returns the prefix of a bids file
     """
-    checker = '-' if folder is False else '_'
+    checker = "-" if folder is False else "_"
     prefix = ""
     idx = 0
     char = filename[idx]
@@ -152,6 +153,7 @@ def get_bids_prefix(filename: str, folder: bool = False) -> str:
 
     return prefix
 
+
 def dir_size(in_dir: str) -> int:
     """
     Returns the number of images the user passed
@@ -162,6 +164,7 @@ def dir_size(in_dir: str) -> int:
             size += 1
 
     return size
+
 
 def dir_foldercount(in_dir: str) -> int:
     """
@@ -199,7 +202,7 @@ def collect_T1(in_dir: str, out_dir: str) -> None:
 
     for root, subs, files in os.walk(in_dir):
         for sub in subs:
-            if(sub in accepted_subfolders):
+            if sub in accepted_subfolders:
                 os.system(f"cp {os.path.join(in_dir, sub)}/anat/* raw_temp_T1/")
 
 
@@ -209,9 +212,14 @@ def merge_bids_output_data(out_data: str) -> None:
     """
     for split in os.listdir(out_data):
         if get_bids_prefix(split, True) == "split":
-            s5_relabeled_dir = os.path.join(out_data, split, "temp_working_dir", "s5_relabeled")
+            s5_relabeled_dir = os.path.join(
+                out_data, split, "temp_working_dir", "s5_relabeled"
+            )
             for img in os.listdir(s5_relabeled_dir):
-                os.system(f"mv {s5_relabeled_dir}/{img} {out_data}/{get_bids_prefix(img, True)}/anat/")
+                os.system(
+                    f"mv {s5_relabeled_dir}/{img} {out_data}/{get_bids_prefix(img, True)}/anat/"
+                )
+
 
 def split_data(in_dir: str, N: int) -> list:
     """
@@ -275,15 +283,9 @@ def merge_output_data(in_dir: str) -> None:
         os.system(
             f"mv {in_dir}/{dir}/temp_working_dir/s1_reorient_lps/* {in_dir}/s1_reorient_lps/"
         )
-        os.system(
-            f"mv {in_dir}/{dir}/temp_working_dir/s2_dlicv/* {in_dir}/s2_dlicv/"
-        )
-        os.system(
-            f"mv {in_dir}/{dir}/temp_working_dir/s3_masked/* {in_dir}/s3_masked/"
-        )
-        os.system(
-            f"mv {in_dir}/{dir}/temp_working_dir/s4_dlmuse/* {in_dir}/s4_dlmuse/"
-        )
+        os.system(f"mv {in_dir}/{dir}/temp_working_dir/s2_dlicv/* {in_dir}/s2_dlicv/")
+        os.system(f"mv {in_dir}/{dir}/temp_working_dir/s3_masked/* {in_dir}/s3_masked/")
+        os.system(f"mv {in_dir}/{dir}/temp_working_dir/s4_dlmuse/* {in_dir}/s4_dlmuse/")
         os.system(
             f"mv {in_dir}/{dir}/temp_working_dir/s5_relabeled/* {in_dir}/s5_relabeled/"
         )

--- a/NiChart_DLMUSE/utils.py
+++ b/NiChart_DLMUSE/utils.py
@@ -205,11 +205,10 @@ def merge_bids_output_data(out_data: str) -> None:
     Move all the images on the s5_relabeled subfolder to the subfolder of their prefix
     """
     dlmuse_images = []
-
-    for img in os.listdir(os.path.join(out_data, "s5_relabeled")):
+    relabeled_dir = os.path.join(out_data, "s5_relabeled")
+    for img in os.listdir(relabeled_dir):
         img_prefix = get_bids_prefix(img)
-        os.system(f"mv {os.path.join(out_data, "s5_relabeled")}/{img} {img_prefix}/anat/")
-
+        os.system(f"mv {relabeled_dir}/{img} {img_prefix}/anat/")
 
 
 def split_data(in_dir: str, N: int) -> list:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # NiChart_DLMUSE
 
+[MacOS Build](https://github.com/CBICA/NiChart_DLMUSE/actions/workflows/macos_build.yml/badge.svg)
+[Ubuntu Build](https://github.com/CBICA/NiChart_DLMUSE/actions/workflows/ubuntu_build.yml/badge.svg)
+[PyPI Stable](https://img.shields.io/pypi/v/NiChart_DLMUSE)
+
 ## Overview
 
 NiChart_DLMUSE is a package that allows the users to process their brain imaging (sMRI) data easily and efficiently.
@@ -34,7 +38,7 @@ This package uses [nnU-Net v2](https://github.com/MIC-DKFZ/nnUNet) as a basis mo
     ```
 
 3. Install NiChart_DLMUSE from GitHub Repo or PyPi
-    
+
     ```bash
     git clone https://github.com/CBICA/NiChart_DLMUSE.git
     cd NiChart_DLMUSE
@@ -48,7 +52,7 @@ This package uses [nnU-Net v2](https://github.com/MIC-DKFZ/nnUNet) as a basis mo
 5. (If needed for your system) Install PyTorch with compatible CUDA.
     You only need to run this step if you experience errors with CUDA while running NiChart_DLMUSE.
     Run "pip uninstall torch torchaudio torchvision".
-    Then follow the [PyTorch installation instructions](https://pytorch.org/get-started/locally/) for your CUDA version. 
+    Then follow the [PyTorch installation instructions](https://pytorch.org/get-started/locally/) for your CUDA version.
 
 6. Run NiChart_DLMUSE. Example usage below
 
@@ -58,7 +62,7 @@ This package uses [nnU-Net v2](https://github.com/MIC-DKFZ/nnUNet) as a basis mo
                      -d                    cpu/cuda/mps
     ```
 
-### Docker/Singularity/Apptainer-based build and installation 
+### Docker/Singularity/Apptainer-based build and installation
 
 #### Docker build
 The package comes already pre-built as a [docker container](https://hub.docker.com/repository/docker/cbica/nichart_dlmuse/general), for convenience. Please see [Usage](#usage) for more information on how to use it. Alternatively, you can build the docker image locally, like so:
@@ -103,7 +107,7 @@ NiChart_DLMUSE -h
 ```
 
 #### Troubleshooting model download failures
-Our model download process creates several deep directory structures. If you are running on Windows and your model download process fails, it may be due to Windows file path limitations. 
+Our model download process creates several deep directory structures. If you are running on Windows and your model download process fails, it may be due to Windows file path limitations.
 
 To enable long path support in Windows 10, version 1607, and later, the registry key `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem LongPathsEnabled (Type: REG_DWORD)` must exist and be set to 1.
 
@@ -125,8 +129,8 @@ docker pull cbica/nichart_dlmuse:1.0.1
 # Replace "-d cuda" with "-d mps" or "-d cpu" as needed...
 # or don't pass at all to automatically use CPU.
 # Each "/path/to/.../on/host" is a placeholder, use your actual paths!
-docker run -it --name DLMUSE_inference --rm 
-    --mount type=bind,source=/path/to/input/on/host,target=/input,readonly 
+docker run -it --name DLMUSE_inference --rm
+    --mount type=bind,source=/path/to/input/on/host,target=/input,readonly
     --mount type=bind,source=/path/to/output/on/host,target=/output
     --gpus all cbica/nichart_dlmuse -d cuda
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # NiChart_DLMUSE
 
-[MacOS Build](https://github.com/CBICA/NiChart_DLMUSE/actions/workflows/macos_build.yml/badge.svg)
-[Ubuntu Build](https://github.com/CBICA/NiChart_DLMUSE/actions/workflows/ubuntu_build.yml/badge.svg)
-[PyPI Stable](https://img.shields.io/pypi/v/NiChart_DLMUSE)
+![MacOS Build](https://github.com/CBICA/NiChart_DLMUSE/actions/workflows/macos_build.yml/badge.svg)
+![Ubuntu Build](https://github.com/CBICA/NiChart_DLMUSE/actions/workflows/ubuntu_build.yml/badge.svg)
+![PyPI Stable](https://img.shields.io/pypi/v/NiChart_DLMUSE)
 
 ## Overview
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,30 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: no
+
+ignore:
+  - "setup.py"
+  - "NiChart_DLMUSE/__main__.py"
+  - "NiChart_DLMUSE/CalcROIVol.py"
+  - "NiChart_DLMUSE/dlmuse_pipeline.py"
+  - "NiChart_DLMUSE/MaskImage.py"
+  - "NiChart_DLMUSE/RelabelROI.py"
+  - "NiChart_DLMUSE/ReorientImage.py"
+  - "NiChart_DLMUSE/SegmentImage.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=2.2.1
+torch --index-url https://download.pytorch.org/whl/nightly/cpu
 DLICV
 DLMUSE
 nibabel>=5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,13 @@
+# Main pipeline
 torch==2.2.1
 DLICV
 DLMUSE
 nibabel>=5.2
+scipy
+
+# Developer tools
+pytest
+pytest-cov
 huggingface_hub
 argparse
-scipy
 pathlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch --index-url https://download.pytorch.org/whl/nightly/cpu
+torch==2.2.1
 DLICV
 DLMUSE
 nibabel>=5.2

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     url="https://github.com/CBICA/NiChart_DLMUSE",
     python_requires=">=3.9",
     install_requires=[
-        "torch",
+        "torch<=2.2.1",
         "DLICV",
         "DLMUSE",
         "huggingface_hub",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from re import A
 
 from setuptools import find_packages, setup
 
@@ -26,7 +25,7 @@ setup(
         "scipy",
         "nibabel",
         "argparse",
-        "pathlib"
+        "pathlib",
     ],
     entry_points={"console_scripts": ["NiChart_DLMUSE = NiChart_DLMUSE.__main__:main"]},
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,10 @@
 from pathlib import Path
+from re import A
 
 from setuptools import find_packages, setup
 
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
-
-with open("requirements.txt") as f:
-    required = f.read().splitlines()
-
 
 setup(
     name="NiChart_DLMUSE",
@@ -20,8 +17,17 @@ setup(
     maintainer="Guray Erus, Kyunglok Baik, Spiros Maggioros, Alexander Getka",
     license="By installing/using DLMUSE, the user agrees to the following license: See https://www.med.upenn.edu/cbica/software-agreement-non-commercial.html",
     url="https://github.com/CBICA/NiChart_DLMUSE",
-    python_requires=">=3.8",
-    install_requires=required,
+    python_requires=">=3.9",
+    install_requires=[
+        "torch",
+        "DLICV",
+        "DLMSUE",
+        "huggingface_hub",
+        "scipy",
+        "nibabel",
+        "argparse",
+        "pathlib"
+    ],
     entry_points={"console_scripts": ["NiChart_DLMUSE = NiChart_DLMUSE.__main__:main"]},
     classifiers=[
         "Intended Audience :: Science/Research",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     install_requires=[
         "torch",
         "DLICV",
-        "DLMSUE",
+        "DLMUSE",
         "huggingface_hub",
         "scipy",
         "nibabel",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,43 +1,53 @@
-from dateutil.relativedelta import WE
-import pytest
 import os
 
-from NiChart_DLMUSE.utils import *
+import pandas as pd
+
+from NiChart_DLMUSE.utils import (
+    get_basename,
+    get_bids_prefix,
+    make_img_list,
+    remove_common_suffix,
+    remove_subfolders,
+    split_data,
+)
 
 
-def testing_get_basename():
+def testing_get_basename() -> None:
     test_file: str = "test.nii.gz"
     assert get_basename(test_file, "", [".nii", ".nii.gz"]) == "test"
 
-    test_file: str = "test.nii"
+    test_file = "test.nii"
     assert get_basename(test_file, "", [".nii", ".nii.gz"]) == "test"
 
-def testing_remove_common_suffix():
+
+def testing_remove_common_suffix() -> None:
     test_files: list = ["test1.nii.gz", "test2.nii.gz", "test3.nii.gz", "test4.nii.gz"]
     correct_res: list = ["test1", "test2", "test3", "test4"]
     assert remove_common_suffix(test_files) == correct_res
 
-    test_files = ["test1.nii.gz"] # WARNING: Single case, review if needed
+    test_files = ["test1.nii.gz"]  # WARNING: Single case, review if needed
     correct_res = ["test1.nii.gz"]
 
     assert remove_common_suffix(test_files) == correct_res
 
-def testing_make_img_list():
+
+def testing_make_img_list() -> None:
     os.system("mkdir test_dataset")
     for i in range(3):
         os.system(f"touch test_dataset/IXI10{i}-Guys-0000-T1.nii.gz")
 
     df_img: pd.DataFrame = make_img_list("test_dataset")
-    df_img = df_img.sort_values(by='MRID')
+    df_img = df_img.sort_values(by="MRID")
     info = {
         "MRID": [f"IXI10{i}" for i in range(3)],
-        "img_path": [os.path.abspath(f"test_dataset/IXI10{i}-Guys-0000-T1.nii.gz") for i in range(3)],
+        "img_path": [
+            os.path.abspath(f"test_dataset/IXI10{i}-Guys-0000-T1.nii.gz")
+            for i in range(3)
+        ],
         "img_base": [f"IXI10{i}-Guys-0000-T1.nii.gz" for i in range(3)],
-        "img_prefix": [f"IXI10{i}-Guys-0000-T1" for i in range(3)]
+        "img_prefix": [f"IXI10{i}-Guys-0000-T1" for i in range(3)],
     }
-    df_test:pd.DataFrame = pd.DataFrame(
-        info
-    )
+    df_test: pd.DataFrame = pd.DataFrame(info)
 
     assert list(df_img["MRID"]) == list(df_test["MRID"])
     assert list(df_img["img_path"]) == list(df_test["img_path"])
@@ -47,10 +57,11 @@ def testing_make_img_list():
     os.system("rm -r test_dataset")
 
 
-def testing_get_bids_prefix():
+def testing_get_bids_prefix() -> None:
     pass
 
-def testing_collect_T1():
+
+def testing_collect_T1() -> None:
     os.system("mkdir test_collect_T1")
 
     # Generate the BIDS input folder for testing
@@ -64,11 +75,12 @@ def testing_collect_T1():
 
     os.system("rm -r test_collect_T1")
 
-def testing_split_data():
+
+def testing_split_data() -> None:
     if os.path.exists("test_split_data"):
         os.system("rm -r test_split_data")
 
-    def generate_random_test_folders(no_files: int = 15):
+    def generate_random_test_folders(no_files: int = 15) -> None:
         os.system("mkdir test_split_data")
         for i in range(no_files):
             if i < 10:
@@ -76,9 +88,9 @@ def testing_split_data():
             else:
                 os.system(f"touch test_split_data/IXI-1{i}-Guys-0000-T1.nii.gz")
 
-    def check_subfolder_count(no_folders: int, count_in: int, count_last: int):
+    def check_subfolder_count(no_folders: int, count_in: int, count_last: int) -> None:
         subfldr_files = []
-        for (idx, subfldr) in enumerate(os.listdir("test_split_data")):
+        for idx, subfldr in enumerate(os.listdir("test_split_data")):
             joined = os.path.join("test_split_data", subfldr)
             if idx < no_folders and os.path.isdir(joined):
                 subfldr_files.append(len(os.listdir(joined)))
@@ -94,7 +106,11 @@ def testing_split_data():
             else:
                 last_count += 1
 
-        assert (last_count == 1 if count_in != count_last else last_count == 0) and (in_count == no_folders - 1 if count_in != count_last else in_count == no_folders)
+        assert (last_count == 1 if count_in != count_last else last_count == 0) and (
+            in_count == no_folders - 1
+            if count_in != count_last
+            else in_count == no_folders
+        )
 
     generate_random_test_folders(12)
     subfolders: list = split_data("test_split_data", 4)
@@ -125,8 +141,9 @@ def testing_split_data():
     check_subfolder_count(1, 1, 1)
     os.system("rm -r test_split_data")
 
-def testing_remove_subfolders():
-    def generate_random_test_folders(no_files: int = 15):
+
+def testing_remove_subfolders() -> None:
+    def generate_random_test_folders(no_files: int = 15) -> None:
         os.system("mkdir test_split_data")
         for i in range(no_files):
             if i < 10:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,147 @@
+from dateutil.relativedelta import WE
+import pytest
+import os
+
+from NiChart_DLMUSE.utils import *
+
+
+def testing_get_basename():
+    test_file: str = "test.nii.gz"
+    assert get_basename(test_file, "", [".nii", ".nii.gz"]) == "test"
+
+    test_file: str = "test.nii"
+    assert get_basename(test_file, "", [".nii", ".nii.gz"]) == "test"
+
+def testing_remove_common_suffix():
+    test_files: list = ["test1.nii.gz", "test2.nii.gz", "test3.nii.gz", "test4.nii.gz"]
+    correct_res: list = ["test1", "test2", "test3", "test4"]
+    assert remove_common_suffix(test_files) == correct_res
+
+    test_files = ["test1.nii.gz"] # WARNING: Single case, review if needed
+    correct_res = ["test1.nii.gz"]
+
+    assert remove_common_suffix(test_files) == correct_res
+
+def testing_make_img_list():
+    os.system("mkdir test_dataset")
+    for i in range(3):
+        os.system(f"touch test_dataset/IXI10{i}-Guys-0000-T1.nii.gz")
+
+    df_img: pd.DataFrame = make_img_list("test_dataset")
+    df_img = df_img.sort_values(by='MRID')
+    info = {
+        "MRID": [f"IXI10{i}" for i in range(3)],
+        "img_path": [os.path.abspath(f"test_dataset/IXI10{i}-Guys-0000-T1.nii.gz") for i in range(3)],
+        "img_base": [f"IXI10{i}-Guys-0000-T1.nii.gz" for i in range(3)],
+        "img_prefix": [f"IXI10{i}-Guys-0000-T1" for i in range(3)]
+    }
+    df_test:pd.DataFrame = pd.DataFrame(
+        info
+    )
+
+    assert list(df_img["MRID"]) == list(df_test["MRID"])
+    assert list(df_img["img_path"]) == list(df_test["img_path"])
+    assert list(df_img["img_base"] == list(df_test["img_base"]))
+    assert list(df_img["img_prefix"] == list(df_test["img_prefix"]))
+
+    os.system("rm -r test_dataset")
+
+
+def testing_get_bids_prefix():
+    pass
+
+def testing_collect_T1():
+    os.system("mkdir test_collect_T1")
+
+    # Generate the BIDS input folder for testing
+    for i in range(9):
+        os.system(f"mkdir test_collect_T1/sub-0{i}")
+        os.system(f"mkdir test_collect_T1/sub-0{i}/anat")
+        os.system(f"touch test_collect_T1/sub-0{i}/anat/IXI-10{i}-Guys-0000-T1.nii.gz")
+
+    for subfolder in os.listdir("test_collect_T1"):
+        assert get_bids_prefix(subfolder) == "sub"
+
+    os.system("rm -r test_collect_T1")
+
+def testing_split_data():
+    if os.path.exists("test_split_data"):
+        os.system("rm -r test_split_data")
+
+    def generate_random_test_folders(no_files: int = 15):
+        os.system("mkdir test_split_data")
+        for i in range(no_files):
+            if i < 10:
+                os.system(f"touch test_split_data/IXI-10{i}-Guys-0000-T1.nii.gz")
+            else:
+                os.system(f"touch test_split_data/IXI-1{i}-Guys-0000-T1.nii.gz")
+
+    def check_subfolder_count(no_folders: int, count_in: int, count_last: int):
+        subfldr_files = []
+        for (idx, subfldr) in enumerate(os.listdir("test_split_data")):
+            joined = os.path.join("test_split_data", subfldr)
+            if idx < no_folders and os.path.isdir(joined):
+                subfldr_files.append(len(os.listdir(joined)))
+            elif idx >= no_folders and os.path.isdir(joined):
+                subfldr_files.append(len(os.listdir(joined)))
+
+        in_count: int = 0
+        last_count: int = 0
+
+        for files in subfldr_files:
+            if files == count_in:
+                in_count += 1
+            else:
+                last_count += 1
+
+        assert (last_count == 1 if count_in != count_last else last_count == 0) and (in_count == no_folders - 1 if count_in != count_last else in_count == no_folders)
+
+    generate_random_test_folders(12)
+    subfolders: list = split_data("test_split_data", 4)
+
+    assert len(subfolders) == 4
+    check_subfolder_count(4, 3, 3)
+    os.system("rm -r test_split_data")
+
+    generate_random_test_folders(20)
+    subfolders = split_data("test_split_data", 4)
+
+    assert len(subfolders) == 4
+    check_subfolder_count(4, 5, 5)
+    os.system("rm -r test_split_data")
+
+    generate_random_test_folders(35)
+    subfolders = split_data("test_split_data", 4)
+
+    assert len(subfolders) == 4
+    check_subfolder_count(4, 9, 8)
+    os.system("rm -r test_split_data")
+
+    generate_random_test_folders(1)
+    subfolders = split_data("test_split_data", 4)
+
+    assert len(subfolders) == 1
+    print(len(subfolders))
+    check_subfolder_count(1, 1, 1)
+    os.system("rm -r test_split_data")
+
+def testing_remove_subfolders():
+    def generate_random_test_folders(no_files: int = 15):
+        os.system("mkdir test_split_data")
+        for i in range(no_files):
+            if i < 10:
+                os.system(f"touch test_split_data/IXI-10{i}-Guys-0000-T1.nii.gz")
+            else:
+                os.system(f"touch test_split_data/IXI-1{i}-Guys-0000-T1.nii.gz")
+
+    generate_random_test_folders(10)
+    remove_subfolders("test_split_data")
+
+    assert len(os.listdir("test_split_data")) == 10
+    os.system("rm -r test_split_data")
+
+    generate_random_test_folders(1)
+    remove_subfolders("test_split_data")
+    assert len(os.listdir("test_split_data")) == 1
+
+    os.system("rm -r test_split_data")


### PR DESCRIPTION
## BIDS I/O
- Now NiChart_DLMUSE supports BIDS input folders 
- It returns the masked images on the same input folder under the anat/ subfolder

## Test cases
Wrote the test cases for the util functions and generated a codecov report.
Fixed bugs with NiChart_DLMUSE parallelization