### PR TITLE
New pipeline function for code usage | Updates on torch version

### DIFF
--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -4,25 +4,25 @@ name: macos build
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  build:
-    runs-on: ["macos-13"]
+    build:
+        runs-on: ["macos-latest"]
 
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install spare scores
-        run: |
-          python -m pip cache purge
-          pip install -r requirements.txt
-          pip install setuptools twine wheel
-          python -m pip install .
-      - name: Run unit tests
-        run: |
-          cd tests/ && pytest --cov=../ --cov-report=xml
-      - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v4.0.1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          slug: CBICA/NiChart_DLMUSE
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+            - name: Install spare scores
+              run: |
+                  python -m pip cache purge
+                  pip install -r requirements.txt
+                  pip install setuptools twine wheel
+                  python -m pip install .
+            - name: Run unit tests
+              run: |
+                  cd tests/ && pytest --cov=../ --cov-report=xml
+            - name: Upload Coverage to Codecov
+              uses: codecov/codecov-action@v4.0.1
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
+                  slug: CBICA/NiChart_DLMUSE

--- a/NiChart_DLMUSE/SegmentImage.py
+++ b/NiChart_DLMUSE/SegmentImage.py
@@ -2,8 +2,6 @@ import glob
 import os
 import shutil
 from typing import Any
-import DLMUSE 
-import DLICV
 
 
 def run_dlicv(

--- a/NiChart_DLMUSE/__init__.py
+++ b/NiChart_DLMUSE/__init__.py
@@ -1,1 +1,1 @@
-from .dlmuse_pipeline import run_pipeline, run_dlicv, run_dlmuse
+from .dlmuse_pipeline import run_dlicv, run_dlmuse, run_dlmuse_pipeline

--- a/NiChart_DLMUSE/__init__.py
+++ b/NiChart_DLMUSE/__init__.py
@@ -1,1 +1,1 @@
-from .dlmuse_pipeline import run_dlicv, run_dlmuse, run_dlmuse_pipeline
+from .dlmuse_pipeline import run_dlicv, run_dlmuse, run_ndlmuse_pipeline

--- a/NiChart_DLMUSE/__main__.py
+++ b/NiChart_DLMUSE/__main__.py
@@ -64,8 +64,7 @@ def main() -> None:
 
     # DEVICE argument
     parser.add_argument(
-        "-d",
-        "--device",
+        "-device",
         type=str,
         help="Device (cpu, cuda, or mps)",
         default=None,

--- a/NiChart_DLMUSE/__main__.py
+++ b/NiChart_DLMUSE/__main__.py
@@ -127,29 +127,20 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    in_dir = args.in_dir
-    out_dir = args.out_dir
-    device = args.device
-    dlicv_extra_args = args.dlicv_args
-    dlmuse_extra_args = args.dlmuse_args
-    clear_cache = args.clear_cache
-    bids = args.bids
-    cores = args.cores
-
     print()
     print("Arguments:")
     print(args)
     print()
 
     run_ndlmuse_pipeline(
-        in_dir,
-        out_dir,
-        device,
-        dlicv_extra_args,
-        dlmuse_extra_args,
-        clear_cache,
-        bids,
-        cores,
+        args.in_dir,
+        args.out_dir,
+        args.device,
+        args.dlicv_extra_args,
+        args.dlmuse_extra_args,
+        args.clear_cache,
+        args.bids,
+        args.cores,
     )
 
 

--- a/NiChart_DLMUSE/__main__.py
+++ b/NiChart_DLMUSE/__main__.py
@@ -7,7 +7,7 @@ Use of this source code is governed by license located in license file: https://
 
 import argparse
 
-from .dlmuse_pipeline import run_dlmuse_pipeline
+from .dlmuse_pipeline import run_ndlmuse_pipeline
 
 # VERSION = pkg_resources.require("NiChart_DLMUSE")[0].version
 VERSION = "1.0.9"
@@ -141,7 +141,7 @@ def main() -> None:
     print(args)
     print()
 
-    run_dlmuse_pipeline(
+    run_ndlmuse_pipeline(
         in_dir,
         out_dir,
         device,

--- a/NiChart_DLMUSE/__main__.py
+++ b/NiChart_DLMUSE/__main__.py
@@ -7,7 +7,7 @@ Use of this source code is governed by license located in license file: https://
 
 import argparse
 
-from .dlmuse_pipeline import run_ndlmuse_pipeline
+from NiChart_DLMUSE.dlmuse_pipeline import run_ndlmuse_pipeline
 
 # VERSION = pkg_resources.require("NiChart_DLMUSE")[0].version
 VERSION = "1.0.9"

--- a/NiChart_DLMUSE/__main__.py
+++ b/NiChart_DLMUSE/__main__.py
@@ -7,10 +7,11 @@ Use of this source code is governed by license located in license file: https://
 
 import argparse
 
+import pkg_resources  # type: ignore
+
 from NiChart_DLMUSE.dlmuse_pipeline import run_ndlmuse_pipeline
 
-# VERSION = pkg_resources.require("NiChart_DLMUSE")[0].version
-VERSION = "1.0.9"
+VERSION = pkg_resources.require("NiChart_DLMUSE")[0].version
 
 
 def main() -> None:

--- a/NiChart_DLMUSE/dlmuse_pipeline.py
+++ b/NiChart_DLMUSE/dlmuse_pipeline.py
@@ -6,12 +6,12 @@ from typing import Any
 
 import pkg_resources  # type: ignore
 
-from .CalcROIVol import apply_create_roi_csv, combine_roi_csv
-from .MaskImage import apply_combine_masks, apply_mask_img
-from .RelabelROI import apply_relabel_rois
-from .ReorientImage import apply_reorient_img, apply_reorient_to_init
-from .SegmentImage import run_dlicv, run_dlmuse
-from .utils import (
+from NiChart_DLMUSE.CalcROIVol import apply_create_roi_csv, combine_roi_csv
+from NiChart_DLMUSE.MaskImage import apply_combine_masks, apply_mask_img
+from NiChart_DLMUSE.RelabelROI import apply_relabel_rois
+from NiChart_DLMUSE.ReorientImage import apply_reorient_img, apply_reorient_to_init
+from NiChart_DLMUSE.SegmentImage import run_dlicv, run_dlmuse
+from NiChart_DLMUSE.utils import (
     collect_T1,
     make_img_list,
     merge_bids_output_data,

--- a/NiChart_DLMUSE/dlmuse_pipeline.py
+++ b/NiChart_DLMUSE/dlmuse_pipeline.py
@@ -1,5 +1,8 @@
 import logging
 import os
+import shutil
+import threading
+from typing import Any
 
 import pkg_resources  # type: ignore
 
@@ -8,7 +11,14 @@ from .MaskImage import apply_combine_masks, apply_mask_img
 from .RelabelROI import apply_relabel_rois
 from .ReorientImage import apply_reorient_img, apply_reorient_to_init
 from .SegmentImage import run_dlicv, run_dlmuse
-from .utils import make_img_list
+from .utils import (
+    collect_T1,
+    make_img_list,
+    merge_bids_output_data,
+    merge_output_data,
+    remove_subfolders,
+    split_data,
+)
 
 # Config vars
 SUFF_LPS = "_LPS.nii.gz"
@@ -35,17 +45,131 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(filename="pipeline.log", encoding="utf-8", level=logging.DEBUG)
 
 
-def run_pipeline(
-    in_data: str,
+def run_dlmuse_pipeline(
+    in_dir: str,
     out_dir: str,
     device: str,
-    dlmuse_extra_args: str = '',
-    dlicv_extra_args: str = '',
-    sub_fldr: int = 1,
-    progress_bar = None,
+    dlicv_extra_args: str,
+    dlmuse_extra_args: str,
+    clear_cache: bool,
+    bids: bool,
+    cores: str,
 ) -> None:
     """
     NiChart pipeline
+
+    :param in_dir: The input directory
+    :type in_dir: str
+    :param out_dir: The output directory
+    :type out_dir: str
+    :type device: cpu/cuda/mps
+    :param device: str
+    :param dlicv_extra_args: Extra arguments for DLICV API
+    :type dlicv_extra_args: str
+    :param dlmuse_extra_args: Extra arguments for DLMUSE API
+    :type dlmuse_extra_args: str
+    :param clear_cache: True if cache should be cleared
+    :type clear_cache: bool
+    :param bids: True if your input is a bids type folder
+    :type bids: bool
+    :param cores: The number of cores(default is 4)
+    :type cores: str
+
+    :rtype: None
+    """
+    if not os.path.isdir(out_dir):
+        print(f"Can't find {out_dir}, creating it...")
+        # os.system(f"mkdir {out_dir}")
+        os.mkdir(out_dir)
+
+    elif len(os.listdir(out_dir)) != 0:
+        print(f"Emptying output folder: {out_dir}...")
+        for root, dirs, files in os.walk(out_dir):
+            for f in files:
+                os.unlink(os.path.join(root, f))
+            for d in dirs:
+                shutil.rmtree(os.path.join(root, d))
+    if clear_cache:
+        os.system("DLICV -i ./dummy -o ./dummy --clear_cache")
+        os.system("DLMUSE -i ./dummy -o ./dummy --clear_cache")
+
+    working_dir = os.path.join(os.path.abspath(out_dir))
+
+    if bids is True:
+        if int(cores) > 1:
+            collect_T1(in_dir, out_dir)
+
+            no_threads = int(cores)
+            subfolders = split_data("raw_temp_T1", no_threads)
+            threads = []
+            for i in range(len(subfolders)):
+                curr_out_dir = out_dir + f"/split_{i}"
+                curr_thread = threading.Thread(
+                    target=run_thread,
+                    args=(
+                        subfolders[i],
+                        curr_out_dir,
+                        device,
+                        dlmuse_extra_args,
+                        dlicv_extra_args,
+                        i,
+                    ),
+                )
+                curr_thread.start()
+                threads.append(curr_thread)
+
+            for t in threads:
+                t.join()
+
+            merge_bids_output_data(working_dir)
+            remove_subfolders("raw_temp_T1")
+            remove_subfolders(out_dir)
+        else:  # No core parallelization
+            run_thread(in_dir, out_dir, device, dlmuse_extra_args, dlicv_extra_args)
+
+    else:  # Non-BIDS
+        if int(cores) > 1:
+            no_threads = int(cores)
+            subfolders = split_data(in_dir, no_threads)
+
+            threads = []
+            for i in range(len(subfolders)):
+                curr_out_dir = out_dir + f"/split_{i}"
+                curr_thread = threading.Thread(
+                    target=run_thread,
+                    args=(
+                        subfolders[i],
+                        curr_out_dir,
+                        device,
+                        dlmuse_extra_args,
+                        dlicv_extra_args,
+                        i,
+                    ),
+                )
+                curr_thread.start()
+                threads.append(curr_thread)
+
+            for t in threads:
+                t.join()
+
+            merge_output_data(out_dir)
+            remove_subfolders(in_dir)
+            remove_subfolders(out_dir)
+        else:  # No core parallelization
+            run_thread(in_dir, out_dir, device, dlmuse_extra_args, dlicv_extra_args)
+
+
+def run_thread(
+    in_data: str,
+    out_dir: str,
+    device: str,
+    dlmuse_extra_args: str = "",
+    dlicv_extra_args: str = "",
+    sub_fldr: int = 1,
+    progress_bar: Any = None,
+) -> None:
+    """
+    Run a thread of the pipeline
 
     :param in_data: the input directory
     :type in_data: str

--- a/NiChart_DLMUSE/dlmuse_pipeline.py
+++ b/NiChart_DLMUSE/dlmuse_pipeline.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(filename="pipeline.log", encoding="utf-8", level=logging.DEBUG)
 
 
-def run_dlmuse_pipeline(
+def run_ndlmuse_pipeline(
     in_dir: str,
     out_dir: str,
     device: str,

--- a/NiChart_DLMUSE/utils.py
+++ b/NiChart_DLMUSE/utils.py
@@ -65,7 +65,9 @@ def remove_common_suffix(list_files: list) -> list:
 
     bnames = list_files
     if len(list_files) == 1:
-        if list_files[0].endswith('_T1'): # If there is a single image with suffix _T1, remove it
+        if list_files[0].endswith(
+            "_T1"
+        ):  # If there is a single image with suffix _T1, remove it
             bnames = [x[0:-3] for x in bnames]
         return bnames
 
@@ -347,7 +349,7 @@ def remove_subfolders(in_dir: str) -> None:
 
 def merge_output_data(in_dir: str) -> None:
     """
-    Takes all the results from the temp_working_fir and moves them into
+    Takes all the results from the temp_working_dir and moves them into
     the output folder
 
     :param in_dir: the input directory

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Main pipeline
-torch==2.2.1
+torch==2.3.1
 DLICV
 DLMUSE
 nibabel>=5.2
@@ -12,3 +12,6 @@ huggingface_hub
 argparse
 pathlib
 pre-commit
+
+# testing
+pandas

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url="https://github.com/CBICA/NiChart_DLMUSE",
     python_requires=">=3.9",
     install_requires=[
-        "torch<=2.2.1",
+        "torch<=2.3.1",
         "DLICV",
         "DLMUSE",
         "huggingface_hub",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -58,7 +58,19 @@ def testing_make_img_list() -> None:
 
 
 def testing_get_bids_prefix() -> None:
-    pass
+    temp_file = "test-1234"
+    assert get_bids_prefix(temp_file) == "test"
+    temp_file = "test-1"
+    assert get_bids_prefix(temp_file) == "test"
+    temp_file = "test"
+    assert get_bids_prefix(temp_file) == "test"
+
+    temp_folder = "test_1234"
+    assert get_bids_prefix(temp_folder, True) == "test"
+    temp_folder = "test_1"
+    assert get_bids_prefix(temp_folder, True) == "test"
+    temp_folder = "test"
+    assert get_bids_prefix(temp_folder, True) == "test"
 
 
 def testing_collect_T1() -> None:


### PR DESCRIPTION
I updated the torch version for up to 2.3.1 for now. The pipeline is tested and the torch version of the other packages(DLMUSE, DLICV, DLWMLS and Spare) will be updated as well once tested. 

Also, implemented @AlexanderGetka-cbica 's request for a pipeline function (run_dlicv_pipeline) so it can be used instead of calling the CLI command inside third-party code.

Also, good thing that the installation of torch with cuda works well. Just fyi the pipeline works with torch 2.4.* versions as well(tested this because cuda 12.4 doesn't support 2.3.1)

P.S: Thanks for the VM Alex.