### PR TITLE
add sitk.ConnectedComponent for refaced data

### DIFF
--- a/NiChart_DLMUSE/__init__.py
+++ b/NiChart_DLMUSE/__init__.py
@@ -1,1 +1,1 @@
-from .dlmuse_pipeline import run_pipeline, run_dlicv, run_dlmuse
+from .dlmuse_pipeline import run_dlicv, run_dlmuse, run_pipeline

--- a/NiChart_DLMUSE/__main__.py
+++ b/NiChart_DLMUSE/__main__.py
@@ -131,6 +131,14 @@ def main() -> None:
         help="Pass additional args to be sent to DLICV (ex. '-nps 1 -npp 1'). It is recommended to surround these args in a set of double quotes. See the DLICV documentation for details.",
     )
 
+    parser.add_argument(
+        "--refaced-data",
+        action="store_true",
+        required=False,
+        default=False,
+        help="If set, refine DLICV mask by keeping only the largest connected component (for refaced data).",
+    )
+
     # HELP argument
     help = "Show this message and exit"
     parser.add_argument("-h", "--help", action="store_true", help=help)
@@ -142,6 +150,7 @@ def main() -> None:
     device = args.device
     dlicv_extra_args = args.dlicv_args
     dlmuse_extra_args = args.dlmuse_args
+    refaced_data = args.refaced_data
 
     print()
     print("Arguments:")
@@ -185,6 +194,7 @@ def main() -> None:
                         device,
                         dlmuse_extra_args,
                         dlicv_extra_args,
+                        refaced_data,
                         i,
                     ),
                 )
@@ -198,7 +208,14 @@ def main() -> None:
             remove_subfolders("raw_temp_T1")
             remove_subfolders(out_dir)
         else:  # No core parallelization
-            run_pipeline(in_dir, out_dir, device, dlmuse_extra_args, dlicv_extra_args)
+            run_pipeline(
+                in_dir,
+                out_dir,
+                device,
+                dlmuse_extra_args,
+                dlicv_extra_args,
+                refaced_data,
+            )
 
     else:  # Non-BIDS
         if int(args.cores) > 1:
@@ -216,6 +233,7 @@ def main() -> None:
                         device,
                         dlmuse_extra_args,
                         dlicv_extra_args,
+                        refaced_data,
                         i,
                     ),
                 )
@@ -229,7 +247,14 @@ def main() -> None:
             remove_subfolders(in_dir)
             remove_subfolders(out_dir)
         else:  # No core parallelization
-            run_pipeline(in_dir, out_dir, device, dlmuse_extra_args, dlicv_extra_args)
+            run_pipeline(
+                in_dir,
+                out_dir,
+                device,
+                dlmuse_extra_args,
+                dlicv_extra_args,
+                refaced_data,
+            )
 
 
 if __name__ == "__main__":

--- a/NiChart_DLMUSE/utils.py
+++ b/NiChart_DLMUSE/utils.py
@@ -65,7 +65,9 @@ def remove_common_suffix(list_files: list) -> list:
 
     bnames = list_files
     if len(list_files) == 1:
-        if list_files[0].endswith('_T1'): # If there is a single image with suffix _T1, remove it
+        if list_files[0].endswith(
+            "_T1"
+        ):  # If there is a single image with suffix _T1, remove it
             bnames = [x[0:-3] for x in bnames]
         return bnames
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ DLICV
 DLMUSE
 nibabel>=5.2
 scipy
+SimpleITK
 
 # Developer tools
 pytest

--- a/scripts/wrapper.py
+++ b/scripts/wrapper.py
@@ -1,16 +1,24 @@
 import argparse
-import shutil
 import os
+import shutil
 import tempfile
 from pathlib import Path
 
 # This wrapper script just adapts NiChart_DLMUSE to take two separate output args. Everything else is passed transparently
 
+
 def main():
     parser = argparse.ArgumentParser(description="Wrapper", allow_abbrev=False)
     parser.add_argument("-i", "--in_dir", required=True, help="Input directory")
-    parser.add_argument("-o1", "--out_segs", required=True, help="Output directory for segmentation files")
-    parser.add_argument("-o2", "--out_csvs", required=True, help="Output directory for CSV files")
+    parser.add_argument(
+        "-o1",
+        "--out_segs",
+        required=True,
+        help="Output directory for segmentation files",
+    )
+    parser.add_argument(
+        "-o2", "--out_csvs", required=True, help="Output directory for CSV files"
+    )
 
     # Parse known args; leave the rest for original app
     args, extra_args = parser.parse_known_args()
@@ -26,8 +34,14 @@ def main():
         tmp_output_path = Path(tmp_output)
 
         # Build command to run original application
-        cmd = ["NiChart_DLMUSE", "-i", input_dir, "-o", str(tmp_output_path)] + extra_args
-        command = ' '.join(cmd)
+        cmd = [
+            "NiChart_DLMUSE",
+            "-i",
+            input_dir,
+            "-o",
+            str(tmp_output_path),
+        ] + extra_args
+        command = " ".join(cmd)
         os.system(command)
 
         # Copy output files
@@ -39,6 +53,7 @@ def main():
                     dest_path = seg_dir / item.relative_to(tmp_output_path)
                     dest_path.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(item, dest_path)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Closes https://github.com/CBICA/NiChart_DLMUSE/issues/76.

This PR added `--refaced-data` cli argument. When not specified, the original pipeline will be run as usual. When specified, run some additional simple ITK commands to:

1. Convert binary image into a connected component image, each component has an integer label.
2. Relabel components so that they are sorted according to size (there is an minimumObjectSize parameter to get rid of small components).
3. Get largest connected componet, label==1 in sorted component image.

Details here: https://discourse.itk.org/t/simpleitk-extract-largest-connected-component-from-binary-image/4958/2

I have tested the following:

* when refacing doesn't cause issues, we have the same ROI volumes both when `--refaced-data` is and is not specified (because the largest component is the same)
*  when refacing causes issues, `--refaced-data` correctly removed the mask component in the face.